### PR TITLE
Verbose test title with project and test filename

### DIFF
--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,4 @@
-
+ 
 import { test as base, TestInfo } from "@playwright/test";
 import { spawn } from "child_process";
 import fs from "fs";
@@ -14,7 +14,7 @@ async function writeFiles(testInfo: TestInfo, files: Files) {
     files = {
       ...files,
       "playwright.config.ts": `
-        module.exports = { projects: [ { name: 'project' } ] };
+        module.exports = { projects: [ { name: 'project' }, { name: 'project2' } ] };
       `,
     };
   }
@@ -50,7 +50,7 @@ async function runPlaywrightTest(
   const args = [require.resolve("@playwright/test/cli"), "test"];
   args.push(
     "--reporter=" + require.resolve("../dist/index.js"),
-    "--workers=2",
+    "--workers=1",
     ...paramList,
   );
   if (additionalArgs) args.push(...additionalArgs);

--- a/test/status.spec.ts
+++ b/test/status.spec.ts
@@ -28,17 +28,29 @@ test("should report test status", async ({ runInlineTest }) => {
     `,
     },
   );
-  let lines = result.split("\n");
-  expect(lines).toEqual([
-    "1..6",
-    "ok 1 - should pass",
-    "not ok 2 - should fail",
+  let 
+  lines = result.split("\n"),
+  expectedLines = [
     // XXX: diagnostics
-    "not ok 3 - should break",
+    "1..12",
+    /^ok 1 - project   a\.test\.ts  should pass \(\d+\.\d{2}s\)/,
+    /^not ok 2 - project   a\.test\.ts  should fail \(\d+\.\d{2}s\)/,
     // XXX: diagnostics
-    "ok 4 - should skip # SKIP for reasons",
-    "ok 5 - should fixme # SKIP",
-    "ok 6 - should expect fail",
+    /^not ok 3 - project   a\.test\.ts  should break \(\d+\.\d{2}s\)/,
+    // XXX: diagnostics
+    /^ok 4 - project   a\.test\.ts  should skip \(\d+\.\d{2}s\) # SKIP for reasons/,
+    /^ok 5 - project   a\.test\.ts  should fixme \(\d+\.\d{2}s\) # SKIP/,
+    /^ok 6 - project   a\.test\.ts  should expect fail \(\d+\.\d{2}s\)/,
+    /^ok 7 - project2  a\.test\.ts  should pass \(\d+\.\d{2}s\)/,
+    /^not ok 8 - project2  a\.test\.ts  should fail \(\d+\.\d{2}s\)/,
+    /^not ok 9 - project2  a\.test\.ts  should break \(\d+\.\d{2}s\)/,
+    /^ok 10 - project2  a\.test\.ts  should skip \(\d+\.\d{2}s\) # SKIP for reasons/,
+    /^ok 11 - project2  a\.test\.ts  should fixme \(\d+\.\d{2}s\) # SKIP/,
+    /^ok 12 - project2  a\.test\.ts  should expect fail \(\d+\.\d{2}s\)/,
     "", // Final newline
-  ]);
+  ];
+  
+  lines.map((line, i) => {
+    expect(line).toMatch(expectedLines[i])
+  })
 });

--- a/test/status.spec.ts
+++ b/test/status.spec.ts
@@ -38,14 +38,14 @@ test("should report test status", async ({ runInlineTest }) => {
     // XXX: diagnostics
     /^not ok 3 - project   a\.test\.ts  should break \(\d+\.\d{2}s\)/,
     // XXX: diagnostics
-    /^ok 4 - project   a\.test\.ts  should skip \(\d+\.\d{2}s\) # SKIP for reasons/,
-    /^ok 5 - project   a\.test\.ts  should fixme \(\d+\.\d{2}s\) # SKIP/,
+    /^ok 4 - project   a\.test\.ts  should skip \(\d+\.\d{2}s\)  # SKIP for reasons/,
+    /^ok 5 - project   a\.test\.ts  should fixme \(\d+\.\d{2}s\)  # SKIP/,
     /^ok 6 - project   a\.test\.ts  should expect fail \(\d+\.\d{2}s\)/,
     /^ok 7 - project2  a\.test\.ts  should pass \(\d+\.\d{2}s\)/,
     /^not ok 8 - project2  a\.test\.ts  should fail \(\d+\.\d{2}s\)/,
     /^not ok 9 - project2  a\.test\.ts  should break \(\d+\.\d{2}s\)/,
-    /^ok 10 - project2  a\.test\.ts  should skip \(\d+\.\d{2}s\) # SKIP for reasons/,
-    /^ok 11 - project2  a\.test\.ts  should fixme \(\d+\.\d{2}s\) # SKIP/,
+    /^ok 10 - project2  a\.test\.ts  should skip \(\d+\.\d{2}s\)  # SKIP for reasons/,
+    /^ok 11 - project2  a\.test\.ts  should fixme \(\d+\.\d{2}s\)  # SKIP/,
     /^ok 12 - project2  a\.test\.ts  should expect fail \(\d+\.\d{2}s\)/,
     "", // Final newline
   ];


### PR DESCRIPTION
rel: https://github.com/preaction/tap-playwright/issues/1

## Changes in this PR

### (1) `onBegin` -> initSuiteStats()
A "suite stat" object is calculated to get the longest project name, test file name and project count.

### (2) `onTestEnd` -> getPaddedFullTestTitle()
Using the "suite stats" a padded title for the test is created including the project and test file name.
It is padded to the right with blanks up to the longest project name and test file name so that the output looks nicely aligned, e.g.

```
    1..12
    ok 1 - project   a.test.ts  should pass (0.01s)
    not ok 2 - project   a.test.ts  should fail (0.01s)
    not ok 3 - project   a.test.ts  should break (0.00s)
    ok 4 - project   a.test.ts  should skip (0.00s)  # SKIP for reasons
    ok 5 - project   a.test.ts  should fixme (0.00s)  # SKIP
    ok 6 - project   a.test.ts  should expect fail (0.01s)
    ok 7 - project2  a.test.ts  should pass (0.00s)
    not ok 8 - project2  a.test.ts  should fail (0.01s)
    not ok 9 - project2  a.test.ts  should break (0.00s)
    ok 10 - project2  a.test.ts  should skip (0.00s)  # SKIP for reasons
    ok 11 - project2  a.test.ts  should fixme (0.00s)  # SKIP
    ok 12 - project2  a.test.ts  should expect fail (0.01s)
```

I would have added a padding for the `ok | not ok` part as well but the TAP spec expects only single spaces here.

### (2.1) `onTestEnd` -> adding duration

The tests results duration value is calculated in seconds and added to the output.

```
    ok 6 - project   a.test.ts  should expect fail (0.01s)
```

### (2.1) `onTestEnd` -> directive

A minor adjustment was made to the ` # SKIP ` directive part by adding a single additional space in front of it. The specs reads as if it is expected here.
