### PR TITLE
Improve log of errored step info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,10 +89,17 @@ class TapReporter implements Reporter {
       let anno = test.annotations.find( a => a.type == "skip" || a.type == "fixme" );
       title += "  # SKIP" + ( anno && anno.description ? ` ${anno.description}` : "" );
     }
+
     // Use console.log directly to skip TAP commenting
     console.log(`${ok} ${idx} - ${title}`);
     if ( result.error ) {
       const err = result.error;
+      const step = result.steps.find(step => step.error)
+
+      if ( step ){
+        const locationStr: string = step.location && ` @ ${step.location?.file}:${step.location?.line}:${step.location?.column}` || ''
+        this.write( 'error', `[${idx}]`, `In step ${step.title}${locationStr}`);
+      }
       if ( err.value ) {
         this.write( 'error', `[${idx}]`, err.value );
       }
@@ -112,16 +119,7 @@ class TapReporter implements Reporter {
   }
 
   onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
-    const idx = this.tests.indexOf( test ) + 1;
-    // XXX: Delay output to re-order tests run in parallel?
-    // When a step has an error, Playwright unwinds the step stack and
-    // calls the onStepEnd method. One of the steps is an "expect" step,
-    // which means playwright has to be instrumenting expect() somehow.
-    // Maybe I can do the same to get a better assertion library working
-    // with this reporter...
-    if ( step.error ) {
-      this.write( 'error', `[${idx}]`, `In step ${step.title}` );
-    }
+    // step info is assed to error out in onTestEnd
   }
 
   write( dest:'log'|'error', prefix: string, text: string|Buffer ) {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,4 @@
-
+ 
 import { test as base, TestInfo } from "@playwright/test";
 import { spawn } from "child_process";
 import fs from "fs";
@@ -14,7 +14,7 @@ async function writeFiles(testInfo: TestInfo, files: Files) {
     files = {
       ...files,
       "playwright.config.ts": `
-        module.exports = { projects: [ { name: 'project' } ] };
+        module.exports = { projects: [ { name: 'project' }, { name: 'project2' } ] };
       `,
     };
   }
@@ -50,7 +50,7 @@ async function runPlaywrightTest(
   const args = [require.resolve("@playwright/test/cli"), "test"];
   args.push(
     "--reporter=" + require.resolve("../dist/index.js"),
-    "--workers=2",
+    "--workers=1",
     ...paramList,
   );
   if (additionalArgs) args.push(...additionalArgs);

--- a/test/status.spec.ts
+++ b/test/status.spec.ts
@@ -28,17 +28,29 @@ test("should report test status", async ({ runInlineTest }) => {
     `,
     },
   );
-  let lines = result.split("\n");
-  expect(lines).toEqual([
-    "1..6",
-    "ok 1 - should pass",
-    "not ok 2 - should fail",
+  let 
+  lines = result.split("\n"),
+  expectedLines = [
     // XXX: diagnostics
-    "not ok 3 - should break",
+    "1..12",
+    /^ok 1 - project   a\.test\.ts  should pass \(\d+\.\d{2}s\)/,
+    /^not ok 2 - project   a\.test\.ts  should fail \(\d+\.\d{2}s\)/,
     // XXX: diagnostics
-    "ok 4 - should skip # SKIP for reasons",
-    "ok 5 - should fixme # SKIP",
-    "ok 6 - should expect fail",
+    /^not ok 3 - project   a\.test\.ts  should break \(\d+\.\d{2}s\)/,
+    // XXX: diagnostics
+    /^ok 4 - project   a\.test\.ts  should skip \(\d+\.\d{2}s\) # SKIP for reasons/,
+    /^ok 5 - project   a\.test\.ts  should fixme \(\d+\.\d{2}s\) # SKIP/,
+    /^ok 6 - project   a\.test\.ts  should expect fail \(\d+\.\d{2}s\)/,
+    /^ok 7 - project2  a\.test\.ts  should pass \(\d+\.\d{2}s\)/,
+    /^not ok 8 - project2  a\.test\.ts  should fail \(\d+\.\d{2}s\)/,
+    /^not ok 9 - project2  a\.test\.ts  should break \(\d+\.\d{2}s\)/,
+    /^ok 10 - project2  a\.test\.ts  should skip \(\d+\.\d{2}s\) # SKIP for reasons/,
+    /^ok 11 - project2  a\.test\.ts  should fixme \(\d+\.\d{2}s\) # SKIP/,
+    /^ok 12 - project2  a\.test\.ts  should expect fail \(\d+\.\d{2}s\)/,
     "", // Final newline
-  ]);
+  ];
+  
+  lines.map((line, i) => {
+    expect(line).toMatch(expectedLines[i])
+  })
 });


### PR DESCRIPTION
Correctly commented in `onStepEnd` that initial `onStepEnd` call is happening before `onTestEnd` and therefore the created log reads a little bumpy.

    #[1] In step expect.toHaveText
    not ok 1 - screens/ModuleScript.spec.js  loads design (14.08s)
    #[1] Error: expect(received).toHaveText(expected)
    #[1] 

I adjusted `onTestEnd` to find the `step`  with `step.error` and add the information inline 

    not ok 1 - screens/ModuleScript.spec.js  loads design (12.75s)
    #[1] In step expect.toHaveText @ /home/user1/dev0/test/screens/ModuleScript.spec.js:12:36`
    #[1] Error: expect(received).toHaveText(expected)
    #[1] 
