### PR TITLE
Improve log of errored step info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,17 @@ class TapReporter implements Reporter {
       let anno = test.annotations.find( a => a.type == "skip" || a.type == "fixme" );
       title += " # SKIP" + ( anno && anno.description ? ` ${anno.description}` : "" );
     }
+
     // Use console.log directly to skip TAP commenting
     console.log(`${ok} ${idx} - ${title}`);
     if ( result.error ) {
       const err = result.error;
+      const step = result.steps.find(step => step.error)
+
+      if ( step ){
+        const locationStr: string = step.location && ` @ ${step.location?.file}:${step.location?.line}:${step.location?.column}` || ''
+        this.write( 'error', `[${idx}]`, `In step ${step.title}${locationStr}`);
+      }
       if ( err.value ) {
         this.write( 'error', `[${idx}]`, err.value );
       }
@@ -57,16 +64,7 @@ class TapReporter implements Reporter {
   }
 
   onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
-    const idx = this.tests.indexOf( test ) + 1;
-    // XXX: Delay output to re-order tests run in parallel?
-    // When a step has an error, Playwright unwinds the step stack and
-    // calls the onStepEnd method. One of the steps is an "expect" step,
-    // which means playwright has to be instrumenting expect() somehow.
-    // Maybe I can do the same to get a better assertion library working
-    // with this reporter...
-    if ( step.error ) {
-      this.write( 'error', `[${idx}]`, `In step ${step.title}` );
-    }
+    // step info is assed to error out in onTestEnd
   }
 
   write( dest:'log'|'error', prefix: string, text: string|Buffer ) {


### PR DESCRIPTION
Correctly commented in `onStepEnd` that initial `onStepEnd` call is happening before `onTestEnd` and therefore the created log reads a little bumpy.

    #[1] In step expect.toHaveText
    not ok 1 - loads design
    #[1] Error: expect(received).toHaveText(expected)
    #[1] 

I adjusted `onTestEnd` to find the `step`  with `step.error` and add the information inline 

    not ok 1 - loads design
    #[1] In step expect.toHaveText @ /home/user1/dev0/test/screens/ModuleScript.spec.js:12:36
    #[1] Error: expect(received).toHaveText(expected)
    #[1] 
